### PR TITLE
Remove linebreak-style rule from .eslintrc (Issue #1408)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
   "rules": {
     # This makes it easier for Windows users to work on the project. Git automatically
     # converts between linebreak styles to unix-style should end up in the repo.
-    "linebreak-style": 0,
     "func-names": 0,
     "comma-dangle": 0,
     "consistent-return": 0,


### PR DESCRIPTION
This pull request references Issue [#1408](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1408).

Removed `"linebreak-style": 0,` from `.eslintrc`

No linter errors were generated as a result of this change. 

Test suite passed all tests after changes were implemented. 

@nicktu12 @bbp5280